### PR TITLE
Lighter red color for todo, easier on the eyes

### DIFF
--- a/template.jinja
+++ b/template.jinja
@@ -30,11 +30,11 @@ h3 {
     float: left;
     width: 33%;
     height: 100%;
-    background-color: #ff704d;
+    background-color: #ff9176;
 }
 
 .todo tr:nth-child(even) {
-    background-color: #ff5c33;
+    background-color: #ff886a;
 }
 
 .started {


### PR DESCRIPTION
On 4k monitors, the red background and dark text is very difficult to read. This commit puts a little extra contrast between them, making it easier to read.